### PR TITLE
Support Labeling from Hugging Face Audio Datasets

### DIFF
--- a/examples/cv_config.json
+++ b/examples/cv_config.json
@@ -1,6 +1,6 @@
 {
     "do_classify": false,
-    "filter_empty_transcript": false,
+    "filter_empty_transcript": true,
     "classifier": {
         "model": "bookbot/distil-wav2vec2-adult-child-cls-52m",
         "max_duration_s": 3.0

--- a/examples/cv_config.json
+++ b/examples/cv_config.json
@@ -1,0 +1,25 @@
+{
+    "do_classify": false,
+    "filter_empty_transcript": false,
+    "classifier": {
+        "model": "bookbot/distil-wav2vec2-adult-child-cls-52m",
+        "max_duration_s": 3.0
+    },
+    "transcriber": {
+        "type": "wav2vec2",
+        "model": "bookbot/wav2vec2-conformer-rel-pos-large-libriphone-timit-cv",
+        "return_timestamps": "char",
+        "chunk_length_s": 30
+    },
+    "do_noise_classify": false,
+    "noise_classifier": {
+        "model": "bookbot/distil-ast-audioset",
+        "minimum_empty_duration": 0.3,
+        "threshold": 0.2
+    },
+    "segmenter": {
+        "type": "phoneme_overlap",
+        "minimum_chunk_duration": 1.0,
+        "keep_whitespace": true
+    }
+}

--- a/examples/run_hf_cv.sh
+++ b/examples/run_hf_cv.sh
@@ -1,0 +1,8 @@
+python speechline/run_hf.py \
+    --dataset_name mozilla-foundation/common_voice_16_1 \
+    --dataset_config en \
+    --dataset_split train \
+    --audio_column_name audio \
+    --text_column_name sentence \
+    --output_dir training \
+    --config examples/cv_config.json

--- a/examples/run_hf_cv_giga.sh
+++ b/examples/run_hf_cv_giga.sh
@@ -6,3 +6,12 @@ python speechline/run_hf.py \
     --text_column_name sentence \
     --output_dir training \
     --config examples/cv_config.json
+
+python speechline/run_hf.py \
+    --dataset_name speechcolab/gigaspeech \
+    --dataset_config l \
+    --dataset_split train \
+    --audio_column_name audio \
+    --text_column_name text \
+    --output_dir training \
+    --config examples/cv_config.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel"]
+requires = ["setuptools==61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ nltk
 g2p_id_py
 lexikos
 gruut
+pydantic<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ levenshtein
 nltk
 g2p_id_py
 lexikos
+gruut

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-importlib_metadata<5
 black
 isort
 flake8
@@ -10,5 +9,5 @@ mkdocs-material==9.0.3
 mkdocstrings==0.19.1
 mkdocstrings-python-legacy==0.2.3
 Pygments==2.15.0
-moto
+moto<5
 nbconvert

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+importlib_metadata<5
 black
 isort
 flake8

--- a/speechline/modules/audio_transcriber.py
+++ b/speechline/modules/audio_transcriber.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Generator, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -78,9 +78,7 @@ class AudioTranscriber(AudioModule):
         """
 
         def _format_timestamps_to_offsets(
-            timestamps: Dict[
-                str, Union[str, List[Dict[str, Union[str, Tuple[float, float]]]]]
-            ],
+            timestamps: Dict[str, Union[str, List[Dict[str, Union[str, Tuple[float, float]]]]]],
             offset_key: str = "text",
             keep_whitespace: bool = False,
         ) -> List[Dict[str, Union[str, float]]]:
@@ -127,9 +125,7 @@ class AudioTranscriber(AudioModule):
             ]
 
         def _format_timestamps_to_transcript(
-            timestamps: Dict[
-                str, Union[str, List[Dict[str, Union[str, Tuple[float, float]]]]]
-            ],
+            timestamps: Dict[str, Union[str, List[Dict[str, Union[str, Tuple[float, float]]]]]],
         ) -> str:
             """
             Formats `AutomaticSpeechRecognitionPipeline`'s timestamp outputs
@@ -143,13 +139,11 @@ class AudioTranscriber(AudioModule):
                 str:
                     Transcript string.
             """
-            return " ".join(
-                [o["text"].strip() for o in timestamps["chunks"] if o["text"] != " "]
-            )
+            return " ".join([o["text"].strip() for o in timestamps["chunks"] if o["text"] != " "])
 
         def _get_audio_array(
             dataset: Dataset,
-        ) -> Dict[str, Union[np.ndarray, int, str]]:
+        ) -> Generator[Dict[str, Union[np.ndarray, int, str]], None, None]:
             for item in dataset:
                 yield {**item["audio"]}
 

--- a/speechline/run_hf.py
+++ b/speechline/run_hf.py
@@ -1,0 +1,210 @@
+# Copyright 2023 [PT BOOKBOT INDONESIA](https://bookbot.id/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from datasets import Audio, load_dataset
+from lexikos import Lexicon
+
+from speechline.config import Config
+from speechline.segmenters import (
+    PhonemeOverlapSegmenter,
+    SilenceSegmenter,
+    WordOverlapSegmenter,
+)
+from speechline.transcribers import Wav2Vec2Transcriber, WhisperTranscriber
+from speechline.utils.dataset import preprocess_audio_transcript
+from speechline.utils.io import export_transcripts_json
+from speechline.utils.tokenizer import WordTokenizer
+
+
+@dataclass
+class Runner:
+    @staticmethod
+    def parse_args(args: List[str]) -> argparse.Namespace:
+        """
+        Utility argument parser function for SpeechLine.
+
+        Args:
+            args (List[str]):
+                List of arguments.
+
+        Returns:
+            argparse.Namespace:
+                Objects with arguments values as attributes.
+        """
+        parser = argparse.ArgumentParser(
+            prog="python speechline/run.py",
+            description="Perform end-to-end speech labeling pipeline.",
+        )
+
+        parser.add_argument(
+            "--dataset_name",
+            type=str,
+            required=True,
+            help="HuggingFace dataset name.",
+        )
+        parser.add_argument(
+            "--dataset_config",
+            type=str,
+            default="default",
+            help="HuggingFace dataset config.",
+        )
+        parser.add_argument(
+            "--dataset_split",
+            type=str,
+            default="train",
+            help="HuggingFace dataset split name.",
+        )
+        parser.add_argument(
+            "--audio_column_name",
+            type=str,
+            default="audio",
+            help="HuggingFace dataset audio column name.",
+        )
+        parser.add_argument(
+            "--text_column_name",
+            type=str,
+            default="text",
+            help="HuggingFace dataset text column name.",
+        )
+        parser.add_argument(
+            "-o",
+            "--output_dir",
+            type=str,
+            required=True,
+            help="Directory to save pipeline results.",
+        )
+        parser.add_argument(
+            "-c",
+            "--config",
+            type=str,
+            default="examples/config.json",
+            help="SpeechLine configuration file.",
+        )
+        return parser.parse_args(args)
+
+    @staticmethod
+    def run(
+        config: Config,
+        output_dir: str,
+        dataset_name: str,
+        dataset_config: str = "default",
+        dataset_split: str = "train",
+        audio_column_name: str = "audio",
+        text_column_name: str = "text",
+    ) -> None:
+        """
+        Runs end-to-end SpeechLine pipeline.
+
+        ### Pipeline Overview
+        - Transcribes audio.
+        - Segments audio into chunks based on silences.
+
+        Args:
+            config (Config):
+                SpeechLine Config object.
+            output_dir (str):
+                Path to output directory.
+            dataset_name (str):
+                HuggingFace dataset name.
+            dataset_config (str, optional):
+                HuggingFace dataset config. Defaults to "default".
+            dataset_split (str, optional):
+                HuggingFace dataset split name. Defaults to "train".
+            audio_column_name (str, optional):
+                HuggingFace dataset audio column name. Defaults to "audio".
+            text_column_name (str, optional):
+                HuggingFace dataset text column name. Defaults to "text".
+        """
+        num_proc = os.cpu_count()
+        dataset = load_dataset(dataset_name, dataset_config, split=dataset_split, trust_remote_code=True)
+
+        if config.filter_empty_transcript:
+            dataset = dataset.filter(lambda example: example[text_column_name] != "", num_proc=num_proc)
+
+        # load transcriber model
+        if config.transcriber.type == "wav2vec2":
+            transcriber = Wav2Vec2Transcriber(config.transcriber.model)
+        elif config.transcriber.type == "whisper":
+            transcriber = WhisperTranscriber(config.transcriber.model)
+
+        # perform audio transcription
+        dataset = dataset.cast_column(audio_column_name, Audio(sampling_rate=transcriber.sampling_rate))
+        dataset = dataset.map(
+            lambda example: {text_column_name: preprocess_audio_transcript(example[text_column_name])},
+            num_proc=num_proc,
+            remove_columns=list(set(dataset.column_names) - set([audio_column_name, text_column_name])),
+        )
+
+        output_offsets = transcriber.predict(
+            dataset,
+            chunk_length_s=config.transcriber.chunk_length_s,
+            output_offsets=True,
+            return_timestamps=config.transcriber.return_timestamps,
+            keep_whitespace=config.segmenter.keep_whitespace,
+        )
+
+        # segment audios based on offsets
+        if config.segmenter.type == "silence":
+            segmenter = SilenceSegmenter()
+        elif config.segmenter.type == "word_overlap":
+            segmenter = WordOverlapSegmenter()
+        elif config.segmenter.type == "phoneme_overlap":
+            lexicon = Lexicon()
+            if config.segmenter.lexicon_path:
+                with open(config.segmenter.lexicon_path) as json_file:
+                    lex = json.load(json_file)
+                # merge dict with lexicon
+                for k, v in lex.items():
+                    lexicon[k] = lexicon[k].union(set(v)) if k in lexicon else set(v)
+            segmenter = PhonemeOverlapSegmenter(lexicon)
+
+        tokenizer = WordTokenizer()
+
+        def export_and_chunk(example, idx):
+            offset = output_offsets[idx]
+            # chunk audio into segments
+            segmenter.chunk_audio_segments(
+                example[audio_column_name],
+                output_dir,
+                offset,
+                minimum_chunk_duration=config.segmenter.minimum_chunk_duration,
+                silence_duration=config.segmenter.silence_duration,
+                ground_truth=tokenizer(example[text_column_name]),
+            )
+
+        dataset = dataset.map(
+            export_and_chunk, with_indices=True, num_proc=num_proc, desc="Segmenting Audio into Chunks"
+        )
+
+
+if __name__ == "__main__":
+    args = Runner.parse_args(sys.argv[1:])
+    config = Config(args.config)
+    Runner.run(
+        config,
+        args.output_dir,
+        args.dataset_name,
+        args.dataset_config,
+        args.dataset_split,
+        args.audio_column_name,
+        args.text_column_name,
+    )

--- a/speechline/run_hf.py
+++ b/speechline/run_hf.py
@@ -140,9 +140,6 @@ class Runner:
         dataset = load_dataset(dataset_name, dataset_config, split=dataset_split, trust_remote_code=True)
         # dataset = dataset.select(range(100))
 
-        if config.filter_empty_transcript:
-            dataset = dataset.filter(lambda example: example[text_column_name] != "", num_proc=num_proc)
-
         # load transcriber model
         if config.transcriber.type == "wav2vec2":
             transcriber = Wav2Vec2Transcriber(config.transcriber.model)
@@ -156,6 +153,9 @@ class Runner:
             num_proc=num_proc,
             remove_columns=list(set(dataset.column_names) - set([audio_column_name, text_column_name])),
         )
+
+        if config.filter_empty_transcript:
+            dataset = dataset.filter(lambda example: example[text_column_name] != "", num_proc=num_proc)
 
         output_offsets = transcriber.predict(
             dataset,
@@ -205,6 +205,7 @@ class Runner:
             )
 
         thread_map(segment_audio, range(len(dataset)), desc="Segmenting Audio into Chunks", total=len(dataset))
+
 
 if __name__ == "__main__":
     args = Runner.parse_args(sys.argv[1:])

--- a/speechline/run_hf.py
+++ b/speechline/run_hf.py
@@ -155,7 +155,7 @@ class Runner:
         )
 
         if config.filter_empty_transcript:
-            dataset = dataset.filter(lambda example: example[text_column_name] != "", num_proc=num_proc)
+            dataset = dataset.filter(lambda example: example != "", num_proc=num_proc, input_columns=[text_column_name])
 
         output_offsets = transcriber.predict(
             dataset,

--- a/speechline/utils/dataset.py
+++ b/speechline/utils/dataset.py
@@ -114,5 +114,5 @@ def preprocess_audio_transcript(text: str) -> str:
     text = re.sub(chars_to_remove_regex, " ", text).lower().strip()
     text = re.sub(r"\s+", " ", text).strip()
     for tag in tags:
-        text = text.replace(tag, "").strip()
+        text = text.replace(tag.lower(), "").strip()
     return text

--- a/speechline/utils/dataset.py
+++ b/speechline/utils/dataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from glob import glob
 from pathlib import Path
 
@@ -68,9 +69,7 @@ def prepare_dataframe(path_to_files: str, audio_extension: str = "wav") -> pd.Da
     df["language"] = df["language_code"].apply(lambda f: f.split("-")[0])
     # ground truth is same filename, except with .txt extension
     df["ground_truth"] = df["audio"].apply(lambda p: Path(p).with_suffix(".txt"))
-    df["ground_truth"] = df["ground_truth"].apply(
-        lambda p: open(p).read() if p.exists() else ""
-    )
+    df["ground_truth"] = df["ground_truth"].apply(lambda p: open(p).read() if p.exists() else "")
     return df
 
 
@@ -90,7 +89,30 @@ def format_audio_dataset(df: pd.DataFrame, sampling_rate: int = 16000) -> Datase
     dataset = Dataset.from_pandas(df)
     dataset.save_to_disk(str(config.HF_DATASETS_CACHE))
     saved_dataset = load_from_disk(str(config.HF_DATASETS_CACHE))
-    saved_dataset = saved_dataset.cast_column(
-        "audio", Audio(sampling_rate=sampling_rate)
-    )
+    saved_dataset = saved_dataset.cast_column("audio", Audio(sampling_rate=sampling_rate))
     return saved_dataset
+
+
+def preprocess_audio_transcript(text: str) -> str:
+    """
+    Preprocesses audio transcript.
+    - Removes punctuation.
+    - Converts to lowercase.
+    - Removes special tags (e.g. GigaSpeech).
+    """
+    tags = [
+        "<COMMA>",
+        "<PERIOD>",
+        "<QUESTIONMARK>",
+        "<EXCLAMATIONPOINT>",
+        "<SIL>",
+        "<MUSIC>",
+        "<NOISE>",
+        "<OTHER>",
+    ]
+    chars_to_remove_regex = "[\,\?\.\!\-\;\:\"\“\%\‘\”\�'\’]"
+    text = re.sub(chars_to_remove_regex, " ", text).lower().strip()
+    text = re.sub(r"\s+", " ", text).strip()
+    for tag in tags:
+        text = text.replace(tag, "").strip()
+    return text

--- a/speechline/utils/io.py
+++ b/speechline/utils/io.py
@@ -15,7 +15,7 @@
 import json
 import os
 from typing import Dict, List, Union
-
+from pathlib import Path
 import numpy as np
 from pydub import AudioSegment
 
@@ -82,6 +82,7 @@ def export_transcripts_json(
         offsets (List[Dict[str, Union[str, float]]]):
             List of offsets.
     """
+    _ = Path(output_json_path).parent.mkdir(parents=True, exist_ok=True)
     with open(output_json_path, "w") as f:
         json.dump(offsets, f, indent=2)
 

--- a/speechline/utils/io.py
+++ b/speechline/utils/io.py
@@ -35,9 +35,22 @@ def pydub_to_np(audio: AudioSegment) -> np.ndarray:
         np.ndarray:
             Resultant NumPy array of AudioSegment.
     """
-    return np.array(audio.get_array_of_samples(), dtype=np.float32).reshape(
-        (-1, audio.channels)
-    ) / (1 << (8 * audio.sample_width - 1))
+    return np.array(audio.get_array_of_samples(), dtype=np.float32).reshape((-1, audio.channels)) / (
+        1 << (8 * audio.sample_width - 1)
+    )
+
+
+def np_f32_to_pydub(audio: Dict[str, Union[np.ndarray, str]]):
+    array = audio["array"]
+    sampling_rate = audio["sampling_rate"]
+    array = np.int16(array * 32767)
+    audio_bytes = array.tobytes()
+    return AudioSegment(
+        data=audio_bytes,
+        sample_width=array.dtype.itemsize,
+        frame_rate=sampling_rate,
+        channels=array.ndim,
+    )
 
 
 def export_transcripts_json(
@@ -73,9 +86,7 @@ def export_transcripts_json(
         json.dump(offsets, f, indent=2)
 
 
-def export_segment_transcripts_tsv(
-    output_tsv_path: str, segment: List[Dict[str, Union[str, float]]]
-) -> None:
+def export_segment_transcripts_tsv(output_tsv_path: str, segment: List[Dict[str, Union[str, float]]]) -> None:
     """
     Export segment transcripts to TSV of structure:
 


### PR DESCRIPTION
A separate `run_hf.py` script has been provided, allowing users to run the command as follows:

```sh
python speechline/run_hf.py \
    --dataset_name mozilla-foundation/common_voice_16_1 \
    --dataset_config en \
    --dataset_split train \
    --audio_column_name audio \
    --text_column_name sentence \
    --output_dir training \
    --config examples/cv_config.json
```

without having to export the audio files to disk. The potential downside is the greater memory usage due to the audio files being kept in memory, although the Hugging Face `datasets` implementation itself is already quite efficient!